### PR TITLE
change crypto library for go

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Currently known implementations in the wild.
 | Language | License | Crypto library used |
 | -------- | ------- | ------------------- |
 | [Elixir](https://github.com/tuupola/branca-elixir) |  MIT | [ArteMisc/libsalty](https://github.com/ArteMisc/libsalty) |
-| [Go](https://github.com/hako/branca) | MIT | [GoKillers/libsodium-go](https://github.com/GoKillers/libsodium-go)
+| [Go](https://github.com/hako/branca) | MIT | [golang/crypto](https://github.com/golang/crypto)
 | [JavaScript](https://github.com/tuupola/branca-js) |  MIT | [jedisct1/libsodium.js](https://github.com/jedisct1/libsodium.js) |
 | [PHP](https://github.com/tuupola/branca-php) | MIT | [paragonie/sodium_compat](https://github.com/paragonie/sodium_compat) |
 | [Python](https://github.com/tuupola/branca-python) | MIT | [jedisct1/libsodium](https://github.com/jedisct1/libsodium) |


### PR DESCRIPTION
The [Go impl of branca](https://github.com/hako/branca) has switched to an official xchachapoly1305 impl in [golang/crypto](https://github.com/golang/crypto), thanks to this change: https://github.com/golang/crypto/commit/f792edd33d2c59a74c4d81e9b9a536e5301a8b83