### PR TITLE
Remove mention of KDF and user

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Authenticated and encrypted API tokens using modern crypto.
 
 ## What?
 
-Branca is a secure easy to use token format which makes it hard to shoot yourself in the foot. It uses IETF XChaCha20-Poly1305 AEAD symmetric encryption to create encrypted and tamperproof tokens. Payload itself is an arbitrary sequence of bytes. You can use for example a JSON object, plain text string or even binary data serialized by [MessagePack](http://msgpack.org/) or [Protocol Buffers](https://developers.google.com/protocol-buffers/).
+Branca is a secure, easy to use token format which makes it hard to shoot yourself in the foot. It uses IETF XChaCha20-Poly1305 AEAD symmetric encryption to create encrypted and tamperproof tokens. The payload itself is an arbitrary sequence of bytes. You can use for example a JSON object, plain text string or even binary data serialized by [MessagePack](http://msgpack.org/) or [Protocol Buffers](https://developers.google.com/protocol-buffers/).
 
 Although not a goal, it is possible to use [Branca as an alternative to JWT](https://appelsiini.net/2017/branca-alternative-to-jwt/). Also see [getting started](https://branca.io/) instructions.
 
-This specification defines the external format and encryption scheme of the token to help developers create their own implementations. Branca is closely based on [Fernet specification](https://github.com/fernet/spec/blob/master/Spec.md).
+This specification defines the external format and encryption scheme of the token to help developers create their own implementations. Branca is closely based on the [Fernet specification](https://github.com/fernet/spec/blob/master/Spec.md).
 
 ## Design Goals
 
@@ -18,7 +18,7 @@ This specification defines the external format and encryption scheme of the toke
 
 ## Token Format
 
-Branca token consists of header, ciphertext and an authentication tag. Header consists of version, timestamp and nonce. Putting them all together we get following structure.
+A Branca token consists of a header, ciphertext and an authentication tag. The header consists of a version, timestamp and nonce. Putting them all together we get following structure:
 
 ```
 Version (1B) || Timestamp (4B) || Nonce (24B) || Ciphertext (*B) || Tag (16B)
@@ -33,27 +33,31 @@ String representation of the above binary token must use base62 encoding with th
 
 ### Version
 
-Version is 8 bits ie. one byte. Currently the only version is `0xBA`. This is a magic byte which you can use to quickly identify a given token. Version number guarantees the token format and encryption algorithm.
+Version is 8 bits ie. one byte. Currently, the only version is `0xBA`. This is a magic byte which you can use to quickly identify a given token. Version number guarantees the token format and encryption algorithm.
 
 ### Timestamp
 
-Timestamp is 32 bits ie. unsigned big endian 4 byte UNIX timestamp. By having a timestamp instead of expiration time enables the consuming side to decide how long tokens are valid. You cannot accidentally create tokens which are valid for the next 10 years.
+Timestamp is 32 bits ie. unsigned big-endian 4 byte UNIX timestamp. By having a timestamp instead of expiration time enables the consuming side to decide how long tokens are valid. You cannot accidentally create tokens which are valid for the next 10 years.
 
-Storing timestamp as unsigned integer allows us to avoid 2038 problem. Unsigned integer overflow will happen in the year 2106. Possible values are 0 - 4294967295.
+Storing the timestamp as an unsigned integer allows us to avoid the 2038 problem. Unsigned integer overflow will happen in the year 2106. Possible values are 0 - 4294967295.
 
 ### Key
 
-This is a symmetric key of 32 arbitrary bytes. The key can be randomly generated using a CSPRNG, derived from a user-password using a password-hashing algorithm such as Argon2, or created during a key-exchange.
+This is a symmetric key of 32 arbitrary bytes. The key can be randomly generated using a CSPRNG or created during a key-exchange for example.
 
 It is the responsibility of the user of Branca, to ensure the strength and confidentiality of the secret key used. See [libsodium](https://libsodium.gitbook.io/doc/quickstart#what-is-the-difference-between-a-secret-key-and-a-password) for more information on the difference between a password and a secret key.
 
 ### Nonce
 
-Nonce is 192 bits ie. 24 bytes. It should be cryptographically secure random bytes. A nonce should never be used more than once with the same secret key between different payloads. It should be generated automatically by the implementing library. Allowing end user to provide their own nonce is a foot gun.
+Nonce is 192 bits ie. 24 bytes. It should be cryptographically secure random bytes. A nonce should never be used more than once with the same secret key between different payloads. It should be generated automatically by the implementing library. Allowing end users to provide their own nonce is a foot gun.
+
+### Payload
+
+Payload is an arbitrary sequence of bytes of any length.
 
 ### Ciphertext
 
-Payload is encrypted and authenticated using [IETF XChaCha20-Poly1305](https://download.libsodium.org/doc/secret-key_cryptography/xchacha20-poly1305_construction.html). Note that this is [Authenticated Encryption with Additional Data (AEAD)](https://tools.ietf.org/html/rfc7539#section-2.8) where the header part of the token is the additional data. This means the data in the header (version, timestamp and nonce) is not encrypted, it is only authenticated. In laymans terms, header can be seen but it cannot be tampered.
+Payload is encrypted and authenticated using [IETF XChaCha20-Poly1305](https://download.libsodium.org/doc/secret-key_cryptography/xchacha20-poly1305_construction.html). Note that this is [Authenticated Encryption with Additional Data (AEAD)](https://tools.ietf.org/html/rfc7539#section-2.8) where the header part of the token is the additional data. This means the data in the header (version, timestamp and nonce) is not encrypted, it is only authenticated. In laymans terms, header can be seen but it cannot be tampered with.
 
 ### Tag
 
@@ -62,16 +66,16 @@ The authentication tag is 128 bits ie. 16 bytes. This is the
 
 ## Working With Tokens
 
-Instructions below assume your crypto library supports combined mode. In combined mode the authentication tag and the encrypted message are stored together. If your crypto library does not provide combined mode the `tag` is last 16 bytes of the `ciphertext|tag` combination.
+Instructions below assume your crypto library supports combined mode. In combined mode, the authentication tag and the encrypted message are stored together. If your crypto library does not provide combined mode, then the `tag` is last 16 bytes of the `ciphertext|tag` combination.
 
 ### Generating a Token
 
 Given a 256 bit ie. 32 byte secret `key` and an arbitrary `payload`, generate a token with the following steps in order:
 
 1. Generate a 24 byte cryptographically secure random `nonce`.
-2. If user has not provided `timestamp` use the current unixtime.
+2. If no `timestamp` is provided, use the current unixtime.
 3. Construct the `header` by concatenating `version`, `timestamp` and `nonce`.
-4. Encrypt the user given payload with IETF XChaCha20-Poly1305 AEAD with user provided secret `key`. Use `header` as the additional data for AEAD.
+4. Encrypt the payload with IETF XChaCha20-Poly1305 AEAD with the `key`. Use `header` as the additional data for the AEAD.
 5. Concatenate the `header` and the returned `ciphertext|tag` combination from step 4.
 6. Base62 encode the entire token.
 


### PR DESCRIPTION
see #37 

- Remove mention of KDF
- Remove mention of "user" to step-by-step description to avoid creating confusion on which user is being talked about
- Small corrections to text