### PR TITLE
Add disclaimer and new section about known implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,20 @@ Optionally the implementing library may use the `timestamp` for additional verif
 
 ## Libraries
 
-Currently known implementations in the wild.
+**Disclaimer:** This list does not guarantee security nor correctness of the libraries mentioned. The list is not guaranteed to be updated either. A user is encouraged to vet any library before using it.
+
+The libraries listed in this section are known implementations of the Branca specification. 
 
 
+**Implementations that do, or previously have, complied with the specification**
+| Language | Repository | License | Crypto library used |
+| -------- | ---------- | ------- | ------------------- |
+| JavaScript | [tuupola/branca-js](https://github.com/tuupola/branca-js) | MIT | [jedisct1/libsodium.js](https://github.com/jedisct1/libsodium.js) |
+| PHP | [tuupola/branca-php](https://github.com/tuupola/branca-php) | MIT | [jedisct1/libsodium](https://github.com/jedisct1/libsodium) |
+| Python | [tuupola/branca-python](https://github.com/tuupola/branca-python) | MIT | [jedisct1/libsodium](https://github.com/jedisct1/libsodium) |
+| Rust | [return/branca](https://github.com/return/branca) | MIT | [orion-rs/orion](https://github.com/orion-rs/orion)
+
+**All currently known implementations in the wild**
 | Language | Repository | License | Crypto library used |
 | -------- | ---------- | ------- | ------------------- |
 | Clojure | [miikka/clj-branca](https://sr.ht/~miikka/clj-branca/) | EPL-2.0 | [terl/lazysodium-java](https://github.com/terl/lazysodium-java) |
@@ -118,7 +129,7 @@ Currently known implementations in the wild.
 | Python | [tuupola/branca-python](https://github.com/tuupola/branca-python) | MIT | [jedisct1/libsodium](https://github.com/jedisct1/libsodium) |
 | Ruby | [thadeu/branca-ruby](https://github.com/thadeu/branca-ruby) | MIT | [RubyCrypto/rbnacl](https://github.com/RubyCrypto/rbnacl)
 | Ruby | [crossoverhealth/branca](https://github.com/crossoverhealth/branca) | MIT | [RubyCrypto/rbnacl](https://github.com/RubyCrypto/rbnacl)
-| Rust | [return/branca](https://github.com/return/branca) | MIT | [brycx/orion](https://github.com/brycx/orion)
+| Rust | [return/branca](https://github.com/return/branca) | MIT | [orion-rs/orion](https://github.com/orion-rs/orion)
 
 ## Acceptance Test Vectors
 


### PR DESCRIPTION
This introduces several changes as part of #37.

- We put a disclaimer at the beginning of the list of known implementations. This way, it's clear that this list does is not to be interpreted as an official endorsement. 

- Another separate list is added in the beginning. It's purpose is, that libraries that have been tested previously to be correct, can be added here. We still don't guarantee this list is updated, but can still provide a better starting point compared to some of the libraries listed later, that aren't compliant at all.

I'd like your take on this additional section @tuupola. The intention is not to provide an endorsement list, just one that contains libraries that have been tested successfully at least once. I think the idea with a checkmark, indicating compliance, as implemented by PASETO suggested in #37 is not the right approach. We don't expect people working on this specification to set aside time to audit a new library, each time a new author wants to add theirs.

With PASETO, I've myself added a library to their list, where I myself indicated that it passed test vectors. I have no idea if this was verified by a third-party at any time. If not, the end result seem equal to simply a author adding their new library - the same level of confidence can be derived from that.

The new list can be update don ad-hoc basis. If someone wanting to use a library verifies it and reports here that it can be moved up the "known to comply at some point" library, we can do so. This was an alternative to a "Recommended libraries" section, but if this is seem better to you @tuupola, we can make that instead.


The last point I want to address, is that: As I've [written about here](https://brycx.github.io/2021/03/21/cve-and-branca-implementations-continued.html), some libraries listed suffer security problems in addition to non-compliance. Do we wish to remove these entirely?