### PR TITLE
Change license of essentialkaos/branca from MIT to Apache-2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Currently known implementations in the wild.
 | .NET | [scottbrady91/IdentityModel](https://github.com/scottbrady91/IdentityModel) | Apache-2.0 | [Bouncy Castle](https://www.bouncycastle.org/csharp/index.html) |
 | Elixir | [tuupola/branca-elixir](https://github.com/tuupola/branca-elixir) | MIT | [ArteMisc/libsalty](https://github.com/ArteMisc/libsalty) |
 | Erlang | [1ma/branca-erl](https://github.com/1ma/branca-erl) | MIT | [jedisct1/libsodium](https://github.com/jedisct1/libsodium) |
-| Go | [essentialkaos/branca](https://github.com/essentialkaos/branca) | MIT | [golang/crypto](https://github.com/golang/crypto)
+| Go | [essentialkaos/branca](https://github.com/essentialkaos/branca) | Apache-2.0 | [golang/crypto](https://github.com/golang/crypto)
 | Go | [hako/branca](https://github.com/hako/branca) | MIT | [golang/crypto](https://github.com/golang/crypto)
 | Go | [juranki/branca](https://github.com/juranki/branca) | MIT | [golang/crypto](https://github.com/golang/crypto)
 | Java | [Kowalski-IO/branca](https://github.com/Kowalski-IO/branca) | MIT | [Bouncy Castle](https://www.bouncycastle.org/java.html) |


### PR DESCRIPTION
License of [`essentialkaos/branca`](https://kaos.sh/branca) has been changed from `MIT` to `Apache-2.0` since [2.0.8](https://kaos.sh/branca/2.0.8).